### PR TITLE
TF-255: Update build for Electron 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI - Test Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  BuildLinux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo ./install-deps.sh
+
+      - name: Test build module (linux-x64)
+        run: npm i && file bin/linux-x64/capnp.node
+
+      - name: Run tests
+        run: npm test
+
+# vim: set nospell:

--- a/README-FOURIER.md
+++ b/README-FOURIER.md
@@ -1,0 +1,6 @@
+This is our clone of the github capnproto/node-capnproto repository, modified for
+use in an electron environment;
+
+- Modifications to build scripts to build against electron headers
+- Modifications to build scripts to allow cross-compile for darwin
+- Bumping dependencies / merging PRs to resolve V8-compatibility issues to support Electron 20.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ you must have development headers for Cap'n Proto and Node.js installed, along
 with the `node-gyp` tool and a GCC new enough for Cap'n Proto (at least 4.7).
 On Debian/Ubuntu, you can install these like so:
 
-    sudo apt-get install nodejs-dev nodejs-legacy capnproto-dev g++
+    sudo apt-get install nodejs-dev nodejs-legacy libcapnp-dev g++
 
 ### From source
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
       'target_name': 'capnp',
       'sources': ['src/node-capnp/capnp.cc'],
       'libraries': ['-lkj', '-lkj-async', '-lcapnp', '-lcapnpc', '-lcapnp-rpc'],
-      'cflags_cc': ['-std=c++14'],
+      'cflags_cc': ['-std=c++17'],
       'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
       'include_dirs': [
         'src',

--- a/build.js
+++ b/build.js
@@ -31,7 +31,6 @@ var force = false, debug = false;
 var
 	arch = process.arch,
 	platform = process.platform,
-	v8 = /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0],
   environment = { ...process.env };
 
 var patchLibPath = false, patchTool = null;
@@ -77,8 +76,10 @@ if (!{ia32: true, x64: true, arm: true}.hasOwnProperty(arch)) {
 	process.exit(1);
 }
 
-// Test for pre-built library
-var modPath = platform+ '-'+ arch+ '-v8-'+ v8;
+// Test for pre-built library. We do not use the v8 version in the target dir
+// as the v8 version we are running with currently may not be the same as that
+// we are building for.
+var modPath = platform + '-' + arch;
 var command = process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp';
 
 if (!force) {

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -euf
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    libcapnp-dev
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capnp",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A wrapper for the C++ Cap'n Proto library",
   "keywords": [
     "capnproto",
@@ -21,7 +21,7 @@
   "main": "src/node-capnp/capnp.js",
   "types": "src/node-capnp/capnp.d.ts",
   "scripts": {
-    "install": "node ./build.js --dist-url=https://electronjs.org/headers --target=20.0.0",
+    "install": "node ./build.js --dist-url=https://electronjs.org/headers --target=20.3.3",
     "test": "electron src/node-capnp/capnp-test.js",
     "build:darwin": "npm run install -- --target_plat=darwin --patch_path=.libs"
   },
@@ -29,7 +29,7 @@
     "nan": "^2.17.0"
   },
   "devDependencies": {
-    "electron": "^20.0.0",
+    "electron": "^20.3.3",
     "node-gyp": "^9.1.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,16 +21,20 @@
   "main": "src/node-capnp/capnp.js",
   "types": "src/node-capnp/capnp.d.ts",
   "scripts": {
-    "install": "node ./build.js --dist-url=https://electronjs.org/headers --target=12.0.2",
-    "test": "node src/node-capnp/capnp-test.js",
+    "install": "node ./build.js --dist-url=https://electronjs.org/headers --target=20.0.0",
+    "test": "electron src/node-capnp/capnp-test.js",
     "build:darwin": "npm run install -- --target_plat=darwin --patch_path=.libs"
   },
   "dependencies": {
-    "nan": "^2.7.0"
+    "nan": "^2.17.0"
+  },
+  "devDependencies": {
+    "electron": "^20.0.0",
+    "node-gyp": "^9.1.0"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/kentonv/node-capnp.git"
+    "url": "git://github.com/fourieraudio/node-capnp.git"
   },
   "engines": {
     "node": ">=10.0"

--- a/src/node-capnp/capnp-test.js
+++ b/src/node-capnp/capnp-test.js
@@ -42,9 +42,7 @@ try {
   goldenPackedFlatBinary = fs.readFileSync("src/node-capnp/testdata/packedflat");
 }
 
-var test = require("./test.capnp");
-assert(test === capnp.import(__dirname + "/test.capnp"));
-assert(test === require("./test"));
+let test = capnp.importFile(__dirname + "/test.capnp");
 
 assert("namespace" in capnp.importSystem("capnp/c++.capnp"));
 

--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -27,9 +27,8 @@ if (typeof CAPNP_NO_DYNAMIC_REQUIRE !== "undefined" && CAPNP_NO_DYNAMIC_REQUIRE)
   v8capnp = require("./capnp.node");
 } else {
   // Look for binary for this platform
-  var v8 = "v8-"+ /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0];
   var modPath = path.join(
-      __dirname, "../../bin", process.platform+ "-" + process.arch + "-" + v8,
+      __dirname, "../../bin", process.platform + "-" + process.arch,
       "capnp");
   try {
     fs.statSync(modPath + ".node");
@@ -38,9 +37,8 @@ if (typeof CAPNP_NO_DYNAMIC_REQUIRE !== "undefined" && CAPNP_NO_DYNAMIC_REQUIRE)
 
     // Also try just "capnp.node". (Mainly for use when building with Ekam rather
     // than npm.)
-    modPath = "./capnp.node";
     try {
-      fs.statSync(path.join(__dirname, "capnp.node"));
+      fs.statSync(modPath = path.join(__dirname, "capnp.node"));
     } catch (ex) {
       // Give up.
       throw new Error(


### PR DESCRIPTION
This commit updates the module to cause it to build for electron 20;

- Increase C++ version to C++17
- Merge upstream node16 changes
- Use latest version of `nan` to work around
  https://github.com/electron/electron/issues/35193
- Do not use the v8 version of the build environment to specify the
  output directory, as it will likely be different from the runtime
  directory.
- Fix test script using out of date APIs.
- It also adds a CI workflow that verifies that the linux node module builds and passes tests.

I propose merging this PR via rebase.