### PR TITLE
TF-322: Fix ReferenceError: loop accidentally references global

### DIFF
--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -81,7 +81,7 @@ require.extensions[".capnp"] = function (module, filename) {
 }
 
 function makeRemotePromise(promise, pipeline) {
-  for (member in pipeline) {
+  for (var member in pipeline) {
     promise[member] = pipeline[member];
   }
 


### PR DESCRIPTION
When building node-capnp for a more rigorous environment, we discovered that a missing `var` binding was causing code to reference an undefined global, causing a ReferenceError and preventing RPC requests from completing successfully. This commit resolves this.