### PR TITLE
Do not freeze Capability objects when they're constructed

### DIFF
--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -255,7 +255,7 @@ function Capability(native, schema) {
   }
   this.schema = schema;
 
-  Object.freeze(this);
+  Object.seal(this);
 }
 
 function Connection(native) {


### PR DESCRIPTION
Previously, attempting to pass an RPC interface or an explicitly-constructed `Capability` as the argument to an RPC call would produce `TypeError: Cannot assign to read only property 'closed' of object '#<Capability>'`. The same error does not occur when an RPC capability is used as a bootstrap interface.

The error is caused by a call to `Object.freeze(this)` at the end of the `Capability` constructor. The `close()` method can then never be called without crashing, because it always attempts to mutate `Capability.closed`, which is a frozen property.

It looks like this use-case (passing a local capability as an argument) isn't exercised by `capnp-test.js`, so it seems likely that this was just a simple oversight. As far as I can tell, none of `Capability`'s properties are mutated elsewhere.

This commit deletes the `Object.freeze(this)` call, which fixes the error without any apparent side-effects.