### PR TITLE
Fix logic error in UvConnectionReceiver.accept

### DIFF
--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -693,7 +693,7 @@ public:
     newFd = ::accept(fd, nullptr, nullptr);
 #endif
 
-    if (!IS_SOCKET_VALID(newFd)) {
+    if (IS_SOCKET_VALID(newFd)) {
       return kj::Own<kj::AsyncIoStream>(kj::heap<UvIoStream>(uvLoop, newFd, NEW_FD_FLAGS));
     } else {
       int error = GET_LAST_SOCKET_ERROR();


### PR DESCRIPTION
Commit 1782cfd seemed to introduce a bug by accidentally inverting the socket validity test in UvConnectionReceiver.accept. Luckily, I don't think this actually affected us as I don't believe we use this functionality.