### PR TITLE
TF-529: Add typing for `connect` call with bootstrap capability

### DIFF
--- a/src/node-capnp/capnp.d.ts
+++ b/src/node-capnp/capnp.d.ts
@@ -41,6 +41,7 @@ declare module Capnp {
   function parse<Builder, Reader>(type: StructSchema<Builder, Reader>, buffer: Buffer): Reader;
   function serialize<Builder, Reader>(type: StructSchema<Builder, Reader>, builder: Builder): Buffer;
   function connect(addr: string): Connection;
+  function connect<Client>(addr: string, clientBootstrapCapability: Client): Connection;
   function importFile<SchemaBag>(path: string): SchemaBag;
   function importSystem<SchemaBag>(path: string): SchemaBag;
 }


### PR DESCRIPTION
Previously, the typescript typing did not support calling `connect()` with a bootstrap capability. This commit resolves this. It is acknowledged that the typing provided does
not make many guarantees.