### PR TITLE
TF-1521: win32: address spurious exceptions during RPC

### DIFF
--- a/README-FOURIER.md
+++ b/README-FOURIER.md
@@ -48,6 +48,50 @@ npm install --platform=darwin --arch=x64 capnp
 See [`README-DARWIN.md`](README-DARWIN.md) for more information about our approach to Darwin
 cross-compilation.
 
+### Windows "Cross"-"Compilation"
+When we say we "support" cross-compilation from `linux` to `win32`, what of course we really mean is
+that we support producing a `win32` distributable node package on a `linux` host. You, dear reader,
+will be particularly overjoyed to learn that at present all this does is copy a committed,
+pre-compiled `capnp.node` blob out of the repository and into the distribution package. Whilst this
+is technically in a sense "compiling" if you look at it sideways, in the same way that walking to
+the pub is "exercise", you would be forgiven for making the argument that this is perhaps somewhat
+missing the point.
+
+If you find yourself needing to make modifications to the C++ in this package, and, heaven forbid,
+want your changes to actually end up in the resultant binary distributed to our dear users, then you
+must;
+
+a) Happen to have an entirely functional build environment present, perhaps by virtue of having done
+this before, or;
+
+b) Set up a Windows build environment from scratch. Hooray! Go directly to jail. Do not pass go.
+
+The steps for accomplishing this sisyphean task include, but may not be limited to, the following:
+
+1. Convince yourself that you don't have time to rewrite the build system to do the
+   cross-compilation properly (TF-1589).
+2. Install Visual Studio C++ Build Tools 2022.
+3. Install `node`. Note that in order to do this, you should first install a node version manager,
+   such as `nvm-windows`, and then actually install `node`. The author is using `node v18.19.0`.
+4. Acquire the repository sources in your build environment.
+5. Install some sort of python. Make sure it ends up on your PATH! Make sure you install the right
+   sort of python. At the moment, `gyp`, upon which the build process is precariously balanced, uses
+   `distutils`, which the python world in its infinite wisdom has burninated in Python 3.12. You
+   must therefore not use that. I hear Python 3.11 is nice.
+6. Open the `x64 Native Tools Command Prompt`. Do not do this sooner, or things you want will not be
+   on your PATH.
+7. Verify that `npm` and `python` are available in your PATH.
+8. Navigate to the repository root. Curse as you realise you are still using `cmd.exe`, a command
+   line interpreter designed exclusively for people who hate themselves.
+9. Issue `npm i`. Watch in amazement as thousands of C++ compiler warnings scroll past. Ignore them.
+   Everything is fine. Go and make a cup of tea.
+10. Approximately 5 minutes later, marvel at the fruit of your labour, visible at
+    `bin/win32-x64/capnp.node`, unless you skipped any of the above steps, in which case curse
+    loudly, go back and do it again.
+
+Currently, the `build.js` rebuilds the entirety of `capnp` every time the module is rebuilt, which
+is slow and may tire you. Modifying `build.js` to prevent this is trivial.
+
 ## Development
 
 To compile the module when developing it, you can use the same `npm install` commands referenced

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capnp",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A wrapper for the C++ Cap'n Proto library",
   "keywords": [
     "capnproto",

--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -189,7 +189,7 @@ kj::_::Debug::Win32Result faWinsockCallNonBlocking(Call&& call) {
 // On more standards-compliant platforms, just leave well enough alone.
 
 #define FA_NONBLOCKING_SOCKCALL(call, ...) \
-    KJ_NONBLOCKING_SYSCALL(call, KJ_EXPAND(__VA_ARGS__))
+    KJ_NONBLOCKING_SYSCALL(call, ##__VA_ARGS__)
 
 #endif
 

--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -145,6 +145,54 @@ ssize_t read(SOCKET fd, void* buf, size_t len) {
 }
 #endif
 
+#ifdef _WIN32
+
+#if _MSC_VER && !defined(__clang__)
+// The KJ_NONBLOCKING_SYSCALL macro checks for specific error codes
+// returned from the call, allowing EAGAIN / EWOULDBLOCK to pass unhindered.
+//
+// Unfortunately, the method by which it checks for these error codes is by inspecting `errno`;
+// see `getOsErrorNumber` in `capnp/src/kj/debug.c++`, called by `Debug::syscall` in
+// `capnp/src/kj/debug.h`, called by the implementation of the macro. However, in the magical world
+// of winsock, errors are *not* reported via `errno` - they are reported via the wonderous
+// `WSAGetLastError` instead. As a result, using `KJ_NONBLOCKING_SYSCALL` on win32 calls to winsock
+// functions results in spurious failures: TF-1521.
+
+template <typename Call>
+kj::_::Debug::Win32Result faWinsockCallNonBlocking(Call&& call) {
+  int result = call();
+
+  // Expect a return value of -1 (SOCKET_ERROR) means failure, but allow WSAEWOULDBLOCK.
+  if (result == -1) {
+      int error = WSAGetLastError();
+
+      if (error == WSAEWOULDBLOCK) {
+          return kj::_::Debug::win32Call(true);
+      } else {
+          return kj::_::Debug::win32Call(false);
+      }
+  } else {
+      return kj::_::Debug::win32Call(true);
+  }
+}
+
+#define FA_NONBLOCKING_SOCKCALL(call, ...) \
+  if (auto _kjWin32Result = ::faWinsockCallNonBlocking([&](){return (call);})) {} else \
+    for (::kj::_::Debug::Fault f(__FILE__, __LINE__, \
+             _kjWin32Result, #call, "" #__VA_ARGS__, __VA_ARGS__);; f.fatal())
+
+#else
+#error "win32: Only implemented for MSVC (sad). See kj debug.h for what you have to do to fix this in a more enlightened future."
+#endif
+
+#else
+// On more standards-compliant platforms, just leave well enough alone.
+
+#define FA_NONBLOCKING_SOCKCALL(call, ...) \
+    KJ_NONBLOCKING_SYSCALL(call, KJ_EXPAND(__VA_ARGS__))
+
+#endif
+
 #ifdef SANDSTORM_BUILD
 #include <sodium/crypto_stream_chacha20.h>
 #endif
@@ -382,7 +430,7 @@ public:
     if ((flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) && CLOSE_SOCKET(fd) < 0) {
       int error = GET_LAST_SOCKET_ERROR();
       KJ_FAIL_SYSCALL("close", error, fd) {
-        fprintf(stderr, "failed to close socket. error code: %d\n", error);
+        KJ_LOG(WARNING, "close() failed", error);
 
         // Recoverable exceptions are safe in destructors.
         break;
@@ -501,7 +549,7 @@ public:
 
   kj::Promise<void> write(const void* buffer, size_t size) override {
     ssize_t writeResult;
-    KJ_NONBLOCKING_SYSCALL(writeResult = ::write(fd, buffer, size)) {
+    FA_NONBLOCKING_SOCKCALL(writeResult = ::write(fd, buffer, size)) {
       return kj::READY_NOW;
     }
 
@@ -549,7 +597,7 @@ private:
     // be included in the final return value.
 
     ssize_t n;
-    KJ_NONBLOCKING_SYSCALL(n = ::read(fd, buffer, maxBytes)) {
+    FA_NONBLOCKING_SOCKCALL(n = ::read(fd, buffer, maxBytes)) {
       return alreadyRead;
     }
 
@@ -608,7 +656,7 @@ private:
       size_t bytesWritten = 0;
       while (bytesWritten < thisIov->iov_len) {
         int writeResult;
-        KJ_NONBLOCKING_SYSCALL(writeResult = ::write(
+        FA_NONBLOCKING_SOCKCALL(writeResult = ::write(
           fd,
           (const void*) (((const byte*) thisIov->iov_base) + bytesWritten),
           thisIov->iov_len - bytesWritten
@@ -725,7 +773,7 @@ public:
           goto retry;
 
         default:
-          fprintf(stderr, "accept() failed. error code: %d\n", error);
+          KJ_LOG(WARNING, "accept() failed", error);
           KJ_FAIL_SYSCALL("accept", error);
       }
 
@@ -795,7 +843,7 @@ public:
         } else if (error != FA_EINTR) {
 
           KJ_FAIL_SYSCALL("connect()", error) {
-            fprintf(stderr, "connect() failed. error code: %d\n", error);
+            KJ_LOG(WARNING, "connect() failed", error);
             break;
           }
           return kj::Own<kj::AsyncIoStream>();
@@ -822,7 +870,7 @@ public:
           KJ_SYSCALL(getsockopt(fd, SOL_SOCKET, SO_ERROR, ptrToErr, &errlen));
           if (err != 0) {
             KJ_FAIL_SYSCALL("connect()", err) {
-              fprintf(stderr, "connect() failed. error code: %d\n", err);
+              KJ_LOG(WARNING, "connect() failed", err);
               break;
             }
           }


### PR DESCRIPTION
It was reported that this module was throwing spurious exceptions during network operations on certain Windows devices. After some investigation, it is revealed that this was because the `KJ_NONBLOCKING_SYSCALL` macro was being used to inspect the outcome of a Winsock call, which results in `errno` being consulted erroneously instead of `WSAGetLastError()`, and thus causing the "accept `EWOULDBLOCK`" logic to be ineffective.

To resolve this, we apply an appropriate* amount of pre-processor fun to define a new macro, `FA_NONBLOCKING_SOCKCALL` which does the "right thing" depending on if you're on Windows or not, resolving the bug.

(*opinions may vary)

This PR bumps the version of the `capnp` package to `0.5.7`, and provides a new pre-compiled module for the "cross-compilation" workflow, which is the output of the code contained in this PR.

I have tested that this resolves the reported bug by manually building a client containing this node module.