### PR TITLE
TF-2580: ci: Upgrade to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Test build module (linux-x64)
         run: npm i && file bin/linux-x64/capnp.node
 
+      # See https://github.com/electron/electron/issues/42510
+      - name: Configure electron SUID sandbox helper
+        run: |
+          sudo chown root: ./node_modules/electron/dist/chrome-sandbox
+          sudo chmod 4755 ./node_modules/electron/dist/chrome-sandbox
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   BuildLinux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This commit upgrades the Github Actions runner used for CI jobs to use image `ubuntu-24.04` instead of `ubuntu-20.04`, as the latter image's retirement is imminent.